### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --installdeps .
+    - cpanm Rose::DBx::TestDB Mail::Box WWW::Sitemap::XML XML::Feed Test::HTTP::Server::Simple HTTP::Server::Simple::Authen Test::LeakTrace
+
+script:
+    - perl Makefile.PL
+    - RELEASE_TESTING=1 make test


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free continuous integration and testing service for open source projects.  This patch adds an initial Travis-CI configuration file which has been tested against the given Perl versions.

This pull request is submitted in the hope that it is useful.  If you have any questions or comments, please don't hesitate to contact me.  If you want anything changed, I'll happily update the pull request and resubmit as necessary.