### PR TITLE
Use 'perl' explicitly as license in metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,7 +65,7 @@ recommends 'DBI'                          => 0;
 recommends 'Term::ProgressBar'            => 0;
 
 perl_version '5.8.3';
-license 'http://dev.perl.org/licenses/';
+license 'perl';
 homepage 'http://dezi.org/';
 bugtracker 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dezi-App';
 repository 'https://github.com/karpet/dezi-app';


### PR DESCRIPTION
The previous value, being a URL, did not conform to the META spec,
making the metadata invalid.

This change also fixes the core [CPANTS](https://cpants.cpanauthors.org/dist/Dezi-App) issue: meta_yml_conforms_to_known_spec.

Hope this helps!  If you want anything changed, just let me know and I'll update the PR as appropriate and resubmit.