### PR TITLE
Bump copyright year to year of latest release

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -46,7 +46,7 @@ You can also look for information at:
 
 =head2 COPYRIGHT AND LICENCE
 
-Copyright (C) 2014 Peter Karman
+Copyright (C) 2015 Peter Karman
 
 This program is free software; you can redistribute it and/or modify it
 under the terms of the GNU General Public License version 2.

--- a/bin/deziapp
+++ b/bin/deziapp
@@ -87,7 +87,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Aggregator.pm
+++ b/lib/Dezi/Aggregator.pm
@@ -420,7 +420,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Aggregator/DBI.pm
+++ b/lib/Dezi/Aggregator/DBI.pm
@@ -395,7 +395,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Aggregator/FS.pm
+++ b/lib/Dezi/Aggregator/FS.pm
@@ -337,7 +337,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Aggregator/Mail.pm
+++ b/lib/Dezi/Aggregator/Mail.pm
@@ -326,7 +326,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Aggregator/MailFS.pm
+++ b/lib/Dezi/Aggregator/MailFS.pm
@@ -195,7 +195,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Aggregator/Spider.pm
+++ b/lib/Dezi/Aggregator/Spider.pm
@@ -1157,7 +1157,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Aggregator/Spider/Response.pm
+++ b/lib/Dezi/Aggregator/Spider/Response.pm
@@ -298,7 +298,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Aggregator/Spider/UA.pm
+++ b/lib/Dezi/Aggregator/Spider/UA.pm
@@ -247,7 +247,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/App.pm
+++ b/lib/Dezi/App.pm
@@ -394,7 +394,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/CLI.pm
+++ b/lib/Dezi/CLI.pm
@@ -656,7 +656,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Cache.pm
+++ b/lib/Dezi/Cache.pm
@@ -157,7 +157,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Indexer.pm
+++ b/lib/Dezi/Indexer.pm
@@ -334,7 +334,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Indexer/Config.pm
+++ b/lib/Dezi/Indexer/Config.pm
@@ -1179,7 +1179,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2006-2009 by Peter Karman
+Copyright 2006-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Indexer/Doc.pm
+++ b/lib/Dezi/Indexer/Doc.pm
@@ -247,7 +247,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/InvIndex.pm
+++ b/lib/Dezi/InvIndex.pm
@@ -239,7 +239,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -253,7 +253,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy.pm
+++ b/lib/Dezi/Lucy.pm
@@ -131,7 +131,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy/Indexer.pm
+++ b/lib/Dezi/Lucy/Indexer.pm
@@ -693,7 +693,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy/InvIndex.pm
+++ b/lib/Dezi/Lucy/InvIndex.pm
@@ -84,7 +84,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy/Result.pm
+++ b/lib/Dezi/Lucy/Result.pm
@@ -146,7 +146,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy/Results.pm
+++ b/lib/Dezi/Lucy/Results.pm
@@ -135,7 +135,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -573,7 +573,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Queue.pm
+++ b/lib/Dezi/Queue.pm
@@ -169,7 +169,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/ReplaceRules.pm
+++ b/lib/Dezi/ReplaceRules.pm
@@ -234,7 +234,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2011 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Result.pm
+++ b/lib/Dezi/Result.pm
@@ -194,7 +194,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Results.pm
+++ b/lib/Dezi/Results.pm
@@ -122,7 +122,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Role.pm
+++ b/lib/Dezi/Role.pm
@@ -141,7 +141,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Searcher.pm
+++ b/lib/Dezi/Searcher.pm
@@ -234,7 +234,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Searcher/SearchOpts.pm
+++ b/lib/Dezi/Searcher/SearchOpts.pm
@@ -138,7 +138,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/Doc.pm
+++ b/lib/Dezi/Test/Doc.pm
@@ -104,7 +104,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/Indexer.pm
+++ b/lib/Dezi/Test/Indexer.pm
@@ -163,7 +163,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2008-2009 by Peter Karman
+Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself. 

--- a/lib/Dezi/Test/InvIndex.pm
+++ b/lib/Dezi/Test/InvIndex.pm
@@ -152,7 +152,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/Result.pm
+++ b/lib/Dezi/Test/Result.pm
@@ -68,7 +68,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/Results.pm
+++ b/lib/Dezi/Test/Results.pm
@@ -79,7 +79,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/ResultsPayload.pm
+++ b/lib/Dezi/Test/ResultsPayload.pm
@@ -64,7 +64,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Test/Searcher.pm
+++ b/lib/Dezi/Test/Searcher.pm
@@ -151,7 +151,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Types.pm
+++ b/lib/Dezi/Types.pm
@@ -226,7 +226,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.

--- a/lib/Dezi/Utils.pm
+++ b/lib/Dezi/Utils.pm
@@ -364,7 +364,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2014 by Peter Karman
+Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
 it under the terms of the GPL v2 or later.


### PR DESCRIPTION
It's good to have the copyright year on par with the most recent release year and this PR implements that change.  I've noticed that sometimes ranges are used and sometimes not.  In each case I've simply updated the most recent year; leaving ranges as-is and not creating a range if one wasn't already present.  If you would specifically like ranges for all copyright years, I can update the PR appropriately and resubmit.