### PR TITLE
Use Perl license consistently throughout project

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -49,6 +49,4 @@ You can also look for information at:
 Copyright (C) 2015 Peter Karman
 
 This program is free software; you can redistribute it and/or modify it
-under the terms of the GNU General Public License version 2.
-
-
+under the same terms as Perl itself.

--- a/bin/deziapp
+++ b/bin/deziapp
@@ -90,7 +90,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/DBI.pm
+++ b/lib/Dezi/Aggregator/DBI.pm
@@ -398,7 +398,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/Mail.pm
+++ b/lib/Dezi/Aggregator/Mail.pm
@@ -329,7 +329,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/App.pm
+++ b/lib/Dezi/App.pm
@@ -397,7 +397,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/CLI.pm
+++ b/lib/Dezi/CLI.pm
@@ -659,7 +659,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/InvIndex.pm
+++ b/lib/Dezi/InvIndex.pm
@@ -242,7 +242,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -256,7 +256,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy.pm
+++ b/lib/Dezi/Lucy.pm
@@ -134,7 +134,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy/Indexer.pm
+++ b/lib/Dezi/Lucy/Indexer.pm
@@ -696,7 +696,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy/InvIndex.pm
+++ b/lib/Dezi/Lucy/InvIndex.pm
@@ -87,7 +87,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy/Result.pm
+++ b/lib/Dezi/Lucy/Result.pm
@@ -149,7 +149,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy/Results.pm
+++ b/lib/Dezi/Lucy/Results.pm
@@ -138,7 +138,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -576,7 +576,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Result.pm
+++ b/lib/Dezi/Result.pm
@@ -197,7 +197,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Results.pm
+++ b/lib/Dezi/Results.pm
@@ -125,7 +125,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Role.pm
+++ b/lib/Dezi/Role.pm
@@ -144,7 +144,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Searcher.pm
+++ b/lib/Dezi/Searcher.pm
@@ -237,7 +237,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Searcher/SearchOpts.pm
+++ b/lib/Dezi/Searcher/SearchOpts.pm
@@ -141,7 +141,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/Doc.pm
+++ b/lib/Dezi/Test/Doc.pm
@@ -107,7 +107,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/InvIndex.pm
+++ b/lib/Dezi/Test/InvIndex.pm
@@ -155,7 +155,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/Result.pm
+++ b/lib/Dezi/Test/Result.pm
@@ -71,7 +71,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/Results.pm
+++ b/lib/Dezi/Test/Results.pm
@@ -82,7 +82,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/ResultsPayload.pm
+++ b/lib/Dezi/Test/ResultsPayload.pm
@@ -67,7 +67,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/Searcher.pm
+++ b/lib/Dezi/Test/Searcher.pm
@@ -154,7 +154,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Types.pm
+++ b/lib/Dezi/Types.pm
@@ -229,7 +229,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Utils.pm
+++ b/lib/Dezi/Utils.pm
@@ -367,7 +367,7 @@ L<https://metacpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the terms of the GPL v2 or later.
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
As mentioned in PR #4, here is a patch to replace mention of the GPL with the Perl Artistic license.