### PR TITLE
Remove superfluous whitespace in POD

### DIFF
--- a/lib/Dezi/Aggregator.pm
+++ b/lib/Dezi/Aggregator.pm
@@ -47,25 +47,25 @@ Dezi::Aggregator - document aggregation base class
  package MyAggregator;
  use Moose;
  extends 'Dezi::Aggregator';
- 
+
  sub get_doc {
     my ($self, $url) = @_;
-    
+
     # do something to create a Dezi::Indexer::Doc object from $url
-    
+
     return $doc;
  }
- 
+
  sub crawl {
     my ($self, @where) = @_;
-    
+
     foreach my $place (@where) {
-       
+
        # do something to search $place for docs to pass to get_doc()
-       
+
     }
  }
- 
+
  1;
 
 =head1 DESCRIPTION

--- a/lib/Dezi/Aggregator/DBI.pm
+++ b/lib/Dezi/Aggregator/DBI.pm
@@ -24,10 +24,10 @@ my $XMLer = Search::Tools::XML->new();    # included in Utils
 Dezi::Aggregator::DBI - index DB records
 
 =head1 SYNOPSIS
-    
+
     use Dezi::Aggregator::DBI;
     use Carp;
-    
+
     my $aggregator = Dezi::Aggregator::DBI->new(
         db => [
             "DBI:mysql:database=movies;host=localhost;port=3306",
@@ -55,7 +55,7 @@ Dezi::Aggregator::DBI - index DB records
         alias_columns   => 1,
         indexer         => Dezi::Indexer::Native->new,
     );
-    
+
     $aggregator->crawl();
 
 

--- a/lib/Dezi/Aggregator/FS.pm
+++ b/lib/Dezi/Aggregator/FS.pm
@@ -28,11 +28,11 @@ Dezi::Aggregator::FS - crawl a filesystem
  my $fs = Dezi::Aggregator::FS->new(
    indexer => Dezi::Indexer->new
  );
-    
+
  $fs->indexer->start;
  $fs->crawl( $path );
  $fs->indexer->finish;
- 
+
 =head1 DESCRIPTION
 
 Dezi::Aggregator::FS is a filesystem aggregator implementation
@@ -120,7 +120,7 @@ sub file_ok {
 
 Called by find() for all directories. You can control
 the recursion into I<directory> via the config() params
- 
+
 =cut
 
 sub dir_ok {

--- a/lib/Dezi/Aggregator/Mail.pm
+++ b/lib/Dezi/Aggregator/Mail.pm
@@ -19,14 +19,14 @@ my $XMLer = Search::Tools::XML->new();
 Dezi::Aggregator::Mail - crawl a mail box
 
 =head1 SYNOPSIS
-    
+
     use Dezi::Aggregator::Mail;
-    
+
     my $aggregator = 
         Dezi::Aggregator::Mail->new( 
             indexer => Dezi::Indexer::Native->new()
         );
-    
+
     $aggregator->indexer->start;
     $aggregator->crawl('path/to/my/maildir');
     $aggregator->indexer->finish;

--- a/lib/Dezi/Aggregator/MailFS.pm
+++ b/lib/Dezi/Aggregator/MailFS.pm
@@ -20,11 +20,11 @@ Dezi::Aggregator::MailFS - crawl a filesystem of email messages
  my $fs = Dezi::Aggregator::MailFS->new(
         indexer => Dezi::Indexer->new
     );
-    
+
  $fs->indexer->start;
  $fs->crawl( $path_to_mail );
  $fs->indexer->finish;
- 
+
 =head1 DESCRIPTION
 
 Dezi::Aggregator::MailFS is a subclass of Dezi::Aggregator::FS

--- a/lib/Dezi/Aggregator/Spider.pm
+++ b/lib/Dezi/Aggregator/Spider.pm
@@ -94,7 +94,7 @@ Dezi::Aggregator::Spider - web aggregator
  my $spider = Dezi::Aggregator::Spider->new(
      indexer => Dezi::Indexer->new
  );
- 
+
  $spider->indexer->start;
  $spider->crawl( 'http://swish-e.org/' );
  $spider->indexer->finish;

--- a/lib/Dezi/Aggregator/Spider/Response.pm
+++ b/lib/Dezi/Aggregator/Spider/Response.pm
@@ -28,7 +28,7 @@ Dezi::Aggregator::Spider::Response - spider response
  my $ua = Dezi::Aggregator::Spider::UA->new;
  my $response = $ua->get('http://swish-e.org/');
  my $http_response = $response->http_response;
- 
+
  # $ua isa LWP::RobotUA subclass
  # $response isa Dezi::Aggregator::Spider::Response
  # $http_response isa HTTP::Response

--- a/lib/Dezi/Aggregator/Spider/UA.pm
+++ b/lib/Dezi/Aggregator/Spider/UA.pm
@@ -34,7 +34,7 @@ Dezi::Aggregator::Spider::UA - spider user agent
 
  use Dezi::Aggregator::Spider::UA;
  my $ua = Dezi::Aggregator::Spider::UA->new;
- 
+
  # $ua is a LWP::RobotUA object
 
 =head1 DESCRIPTION

--- a/lib/Dezi/Indexer.pm
+++ b/lib/Dezi/Indexer.pm
@@ -67,7 +67,7 @@ Dezi::Indexer - base indexer class
     $indexer->process($doc);
  }
  $indexer->finish;
- 
+
 =head1 DESCRIPTION
 
 Dezi::Indexer is a base class implementing the simplest of indexing

--- a/lib/Dezi/Indexer/Config.pm
+++ b/lib/Dezi/Indexer/Config.pm
@@ -158,13 +158,13 @@ Dezi::Indexer::Config - read/write Indexer config files
 =head1 SYNOPSIS
 
  use Dezi::Indexer::Config;
- 
+
  my $config = Dezi::Indexer::Config->new;
  $config->write2();
  $config->read2('path/to/file.conf');
  $config->write3();
- 
- 
+
+
 =head1 DESCRIPTION
 
 The Dezi::Indexer::Config class reads and writes Swish-e 2.x configuration files,
@@ -188,7 +188,7 @@ Example:
  # one two
  # red yellow
  # green blue
- 
+
 
 =head1 METHODS
 
@@ -201,9 +201,9 @@ may be a configuration parameter.
 Example:
 
  my $config = Dezi::Indexer::Config->new( DefaultContents => 'HTML*' );
- 
+
  print "DefaultContents is ", $config->DefaultContents, "\n";
- 
+
 =cut
 
 around BUILDARGS => sub {
@@ -366,12 +366,12 @@ Example:
  use Dezi::Indexer::Config;
  my $config = Dezi::Indexer::Config->new();
  my $parsed = $config->read2( 'my/file.cfg' );
- 
+
  # should print same thing
  print $config->WordCharacters->[0], "\n";
  print $parsed->{WordCharacters}, "\n";
- 
- 
+
+
 =cut
 
 sub read2 {
@@ -678,7 +678,7 @@ equivalents.
  UndefinedMetaNames
  UndefinedXMLAttributes
  XMLClassAttributes
-        
+
 =cut
 
 sub ver2_to_ver3 {

--- a/lib/Dezi/Indexer/Doc.pm
+++ b/lib/Dezi/Indexer/Doc.pm
@@ -63,25 +63,25 @@ Dezi::Indexer::Doc - Document object class for passing to Dezi::Indexer
 
   # subclass Dezi::Indexer::Doc
   # and override filter() method
-  
+
   package MyDoc;
   use Moose;
   extends 'Dezi::Indexer::Doc';
-  
+
   sub filter {
     my $doc = shift;
-    
+
     # alter url
     my $url = $doc->url;
     $url =~ s/my.foo.com/my.bar.org/;
     $doc->url( $url );
-    
+
     # alter content
     my $buf = $doc->content;
     $buf =~ s/foo/bar/gi;
     $doc->content( $buf );
   }
-  
+
   1;
 
 =head1 DESCRIPTION

--- a/lib/Dezi/InvIndex.pm
+++ b/lib/Dezi/InvIndex.pm
@@ -120,7 +120,7 @@ Dezi::InvIndex - base class for Dezi inverted indexes
  my $index = Dezi::InvIndex->new(path => 'path/to/index');
  print $index;  # prints $index->path
  my $header = $index->get_header();  # $meta isa Dezi::InvIndex::Header object
- 
+
 =head1 DESCRIPTION
 
 A Dezi::InvIndex is a base class for defining different inverted index formats.

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -144,7 +144,7 @@ Dezi::InvIndex::Header - read/write InvIndex metadata
  for my $key (keys %{ $meta->data }) {
     dump $meta->$key;
  }
- 
+
 =head1 DESCRIPTION
 
 A Dezi::InvIndex::Header object represents the metadata for an

--- a/lib/Dezi/Lucy.pm
+++ b/lib/Dezi/Lucy.pm
@@ -24,9 +24,9 @@ Dezi::Lucy - Dezi Apache Lucy backend
     indexer    => 'lucy',
     config     => 'path/to/dezi.conf',
  );
- 
+
  $app->run('path/to/files');
- 
+
  # then search the index
  my $searcher = Dezi::Lucy::Searcher->new(
     invindex => 'path/to/dezi.index',

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -34,14 +34,14 @@ has 'nfs_mode'             => ( is => 'rw', isa => Bool, default => sub {0} );
 Dezi::Lucy::Searcher - Dezi Apache Lucy Searcher
 
 =head1 SYNOPSIS
- 
+
  my $searcher = Dezi::Lucy::Searcher->new(
      invindex             => 'path/to/index',
      max_hits             => 1000,
      find_relevant_fields => 1,   # default: 0
      nfs_mode             => 1,   # default: 0
  );
-                
+
  my $results = $searcher->search( 'foo bar' );
  while (my $result = $results->next) {
      printf("%4d %s\n", $result->score, $result->uri);

--- a/lib/Dezi/Queue.pm
+++ b/lib/Dezi/Queue.pm
@@ -15,7 +15,7 @@ Dezi::Queue - simple in-memory FIFO queue class
 
  use Dezi::Queue;
  my $queue = Dezi::Queue->new;
- 
+
  $queue->put( 'foo' );
  $queue->size;          # returns number of items in queue (1)
  $queue->peek;          # returns 'foo' (next value for get())

--- a/lib/Dezi/ReplaceRules.pm
+++ b/lib/Dezi/ReplaceRules.pm
@@ -47,7 +47,7 @@ in a Dezi::Indexer::Config object or config file.
 Constructor for new ReplaceRules object. I<rules> should be an array
 of strings as defined in
 L<http://swish-e.org/docs/swish-config.html#replacerules>.
- 
+
 =head2 BUILDARGS
 
 Internal method. Allows for single argument to new().

--- a/lib/Dezi/Result.pm
+++ b/lib/Dezi/Result.pm
@@ -16,7 +16,7 @@ has 'property_map' => ( is => 'ro', isa => 'HashRef', required => 1 );
 Dezi::Result - abstract result class
 
 =head1 SYNOPSIS
-                
+
  my $results = $searcher->search( 'foo bar' );
  while (my $result = $results->next) {
      printf("%4d %s\n", $result->score, $result->uri);

--- a/lib/Dezi/Results.pm
+++ b/lib/Dezi/Results.pm
@@ -23,7 +23,7 @@ Dezi::Results - base results class
                     query_class     => 'Dezi::Query',
                     query_parser    => $swish_prog_queryparser,
                 );
-                
+
  my $results = $searcher->search( 'foo bar' );
  while (my $result = $results->next) {
      printf("%4d %s\n", $result->score, $result->uri);

--- a/lib/Dezi/Role.pm
+++ b/lib/Dezi/Role.pm
@@ -42,7 +42,7 @@ Dezi::Role - common attributes for Dezi classes
  with 'Dezi::Role';
  # other stuff
  1;
- 
+
  # see METHODS for what you get for free
 
 =head1 DESCRIPTION

--- a/lib/Dezi/Searcher.pm
+++ b/lib/Dezi/Searcher.pm
@@ -41,7 +41,7 @@ Dezi::Searcher - base searcher class
                     invindex        => 'path/to/index',
                     max_hits        => 1000,
                 );
-                
+
  my $results = $searcher->search( 'foo bar' );
  while (my $result = $results->next) {
      printf("%4d %s\n", $result->score, $result->uri);

--- a/lib/Dezi/Test/Indexer.pm
+++ b/lib/Dezi/Test/Indexer.pm
@@ -80,7 +80,7 @@ Dezi::Test::Indexer - test indexer class
 =head1 SYNOPSIS
 
  use Dezi::Test::Indexer;
- 
+
  my $spider = Dezi::Aggregator::Spider->new(
     indexer => Dezi::Test::Indexer->new()
  );

--- a/lib/Dezi/Utils.pm
+++ b/lib/Dezi/Utils.pm
@@ -26,14 +26,14 @@ Dezi::Utils - utility variables and methods
 =head1 SYNOPSIS
 
  use Dezi::Utils;
- 
+
  my $ext = Dezi::Utils->get_file_ext( $filename );
  my $mime = Dezi::Utils->get_mime( $filename );
  if (Dezi::Utils->looks_like_gz( $filename )) {
      $mime = Dezi::Utils->get_real_mime( $filename );
  }
  my $parser = Dezi::Utils->get_parser_for_mime( $mime );
- 
+
 =head1 DESCRIPTION
 
 This class provides commonly used variables and methods


### PR DESCRIPTION
`podchecker` found that there were several lines within POD text that
contained nothing but whitespace.  This patch removes this superfluous
whitespace and hence silences the `podchecker` warnings.