### PR TITLE
Purge trailing whitespace in source files

### DIFF
--- a/bin/deziapp
+++ b/bin/deziapp
@@ -42,7 +42,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Aggregator.pm
+++ b/lib/Dezi/Aggregator.pm
@@ -81,7 +81,7 @@ of aggregators that crawl the filesystem and web, respectively.
 
 =head2 BUILD
 
-Set object flags per Dezi::Class API. These are also accessors, 
+Set object flags per Dezi::Class API. These are also accessors,
 and include:
 
 =over
@@ -381,7 +381,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -423,7 +423,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/DBI.pm
+++ b/lib/Dezi/Aggregator/DBI.pm
@@ -61,17 +61,17 @@ Dezi::Aggregator::DBI - index DB records
 
 =head1 DESCRIPTION
 
-Dezi::Aggregator::DBI is a Dezi::Aggregator subclass 
+Dezi::Aggregator::DBI is a Dezi::Aggregator subclass
 designed for providing full-text search for databases.
 
 =head1 METHODS
 
-Since Dezi::Aggregator::DBI inherits from Dezi::Aggregator, 
+Since Dezi::Aggregator::DBI inherits from Dezi::Aggregator,
 read that documentation first. Any overridden methods are documented here.
 
 =head2 new( I<opts> )
 
-Create new aggregator object. 
+Create new aggregator object.
 
 The following I<opts> are required:
 
@@ -88,7 +88,7 @@ passed to connect(). Otherwise it will be passed to connect as is.
 =item schema => I<db_schema>
 
 I<db_schema> is a hashref of table names and column descriptions.
-Each key should be a table name. Each value should be a hashref of 
+Each key should be a table name. Each value should be a hashref of
 column descriptions, where the key is the column name and the value
 is a hashref of type and bias. See the SYNOPSIS.
 
@@ -126,7 +126,7 @@ The character to use when C<use_quotes> is true. Default is B<`> (backtick).
 
 =back
 
-B<NOTE:> The new() method simply inherits from Dezi::Aggregator, 
+B<NOTE:> The new() method simply inherits from Dezi::Aggregator,
 so any params valid for that method are allowed here.
 
 =head2 BUILD
@@ -350,7 +350,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Aggregator/FS.pm
+++ b/lib/Dezi/Aggregator/FS.pm
@@ -298,7 +298,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -340,7 +340,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/Mail.pm
+++ b/lib/Dezi/Aggregator/Mail.pm
@@ -22,8 +22,8 @@ Dezi::Aggregator::Mail - crawl a mail box
 
     use Dezi::Aggregator::Mail;
 
-    my $aggregator = 
-        Dezi::Aggregator::Mail->new( 
+    my $aggregator =
+        Dezi::Aggregator::Mail->new(
             indexer => Dezi::Indexer::Native->new()
         );
 
@@ -41,8 +41,8 @@ Dezi::Aggregator::Mail uses Mail::Box, available from CPAN.
 
 =head1 METHODS
 
-Since Dezi::Aggregator::Mail inherits from Dezi::Aggregator, 
-read the Dezi::Aggregator docs first. 
+Since Dezi::Aggregator::Mail inherits from Dezi::Aggregator,
+read the Dezi::Aggregator docs first.
 Any overridden methods are documented here.
 
 =head2 BUILD
@@ -92,7 +92,7 @@ sub BUILD {
 
 =head2 crawl( I<path_to_maildir> )
 
-Create index. 
+Create index.
 
 Returns number of emails indexed.
 
@@ -281,7 +281,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Aggregator/MailFS.pm
+++ b/lib/Dezi/Aggregator/MailFS.pm
@@ -106,7 +106,7 @@ sub file_ok {
 
 =head2 get_doc( I<url> )
 
-Overrides parent class to delegate the creation of the 
+Overrides parent class to delegate the creation of the
 Dezi::Indexer::Doc object to Dezi::Aggregator::Mail->get_doc().
 
 Returns a Dezi::Indexer::Doc object.
@@ -156,7 +156,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -198,7 +198,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/Spider.pm
+++ b/lib/Dezi/Aggregator/Spider.pm
@@ -229,7 +229,7 @@ Number of seconds to wait before skipping manual prompt for username/password.
 
 =item credentials I<user:pass>
 
-String with C<username>:C<password> pair to be used when prompted by 
+String with C<username>:C<password> pair to be used when prompted by
 the server.
 
 =item follow_redirects I<1|0>
@@ -711,7 +711,7 @@ sub get_doc {
 
 Called internally when the server returns a 401 or 403 response.
 Will attempt to determine the correct credentials for I<uri>
-based on the previous attempt in I<response> and what you 
+based on the previous attempt in I<response> and what you
 have configured in B<credentials>, B<authn_callback> or when
 manually prompted.
 
@@ -1040,7 +1040,7 @@ sub looks_like_sitemap {
 =head2 crawl( I<uri> )
 
 Implements the required crawl() method. Recursively fetches I<uri>
-and its child links to a depth set in max_depth(). 
+and its child links to a depth set in max_depth().
 
 Will quit after max_files() unless max_files==0.
 
@@ -1118,7 +1118,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -1160,7 +1160,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/Spider/Response.pm
+++ b/lib/Dezi/Aggregator/Spider/Response.pm
@@ -263,7 +263,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -301,7 +301,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Aggregator/Spider/UA.pm
+++ b/lib/Dezi/Aggregator/Spider/UA.pm
@@ -39,7 +39,7 @@ Dezi::Aggregator::Spider::UA - spider user agent
 
 =head1 DESCRIPTION
 
-Dezi::Aggregator::Spider::UA is a subclass of 
+Dezi::Aggregator::Spider::UA is a subclass of
 LWP::RobotUA.
 
 =head1 METHODS
@@ -212,7 +212,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -250,7 +250,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/App.pm
+++ b/lib/Dezi/App.pm
@@ -130,7 +130,7 @@ Hashref passed directly to indexer->new.
 
 =item invindex
 
-String or Path::Class::Dir pointing at index directory, 
+String or Path::Class::Dir pointing at index directory,
 or a L<Dezi::InvIndex> instance.
 
 =item filter
@@ -349,7 +349,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/CLI.pm
+++ b/lib/Dezi/CLI.pm
@@ -468,11 +468,11 @@ sub _commands {
     my $usage = <<EOF;
  synopsis:
     $CLI_NAME [-E N] [-i dir file ... ] [-S aggregator] [-c file] [-f invindex] [-l] [-v (num)] [-I name=val]
-    $CLI_NAME -q 'word1 word2 ...' [-f file1 file2 ...] 
-          [-s sortprop1 [asc|desc] ...] 
+    $CLI_NAME -q 'word1 word2 ...' [-f file1 file2 ...]
+          [-s sortprop1 [asc|desc] ...]
           [-H num]
-          [-m num] 
-          [-x output_format] 
+          [-m num]
+          [-x output_format]
           [-L prop low high]
     $CLI_NAME -N path/to/compare/file or date
     $CLI_NAME -V
@@ -611,7 +611,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Cache.pm
+++ b/lib/Dezi/Cache.pm
@@ -118,7 +118,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -160,7 +160,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Indexer.pm
+++ b/lib/Dezi/Indexer.pm
@@ -95,7 +95,7 @@ A Dezi::Indexer::Config object or file name.
 
 =item flush
 
-The number of indexed docs at which in-memory changes 
+The number of indexed docs at which in-memory changes
 should be written to disk.
 
 =item invindex
@@ -295,7 +295,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -337,7 +337,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Indexer/Config.pm
+++ b/lib/Dezi/Indexer/Config.pm
@@ -194,7 +194,7 @@ Example:
 
 =head2 new( I<params> )
 
-Instantiate a new Config object. 
+Instantiate a new Config object.
 Takes a hash of key/value pairs, where each key
 may be a configuration parameter.
 
@@ -429,7 +429,7 @@ Writes Swish-e version 2 compatible config file.
 If I<path/file> is omitted, a temp file will be
 written using File::Temp.
 
-If I<prog_mode> is true all config directives 
+If I<prog_mode> is true all config directives
 inappropriate for the -S prog mode in the Native::Indexer
 are skipped. The default is false.
 
@@ -1130,7 +1130,7 @@ __END__
 
 =head1 CAVEATS
 
-IgnoreTotalWordCountWhenRanking defaults to 0 
+IgnoreTotalWordCountWhenRanking defaults to 0
 which is B<not> the default in Swish-e 2.x.
 
 =head1 AUTHOR
@@ -1140,7 +1140,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -1182,7 +1182,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2006-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Indexer/Doc.pm
+++ b/lib/Dezi/Indexer/Doc.pm
@@ -208,7 +208,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -250,7 +250,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/InvIndex.pm
+++ b/lib/Dezi/InvIndex.pm
@@ -143,13 +143,13 @@ Example:
 
 =head2 path
 
-Returns a Path::Class::Dir object representing the directory path to the index. 
-The path is a directory which contains the various files that comprise the 
+Returns a Path::Class::Dir object representing the directory path to the index.
+The path is a directory which contains the various files that comprise the
 index.
 
 =head2 get_header
 
-Returns a Dezi::InvIndex::Header object with which you can query 
+Returns a Dezi::InvIndex::Header object with which you can query
 information about the index.
 
 =head2 header_file
@@ -194,7 +194,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -208,7 +208,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy.pm
+++ b/lib/Dezi/Lucy.pm
@@ -62,13 +62,13 @@ offers a few advantages:
 =item Aggregators and Filters
 
 You get to use all of Dezi's Aggregators and SWISH::Filter support.
-So you can easily index all kinds of file formats 
-(email, .txt, .html, .xml, .pdf, .doc, .xls, etc) 
+So you can easily index all kinds of file formats
+(email, .txt, .html, .xml, .pdf, .doc, .xls, etc)
 without writing your own parser.
 
 =item SWISH::3
 
-SWISH::3 offers fast and robust XML and HTML parsers 
+SWISH::3 offers fast and robust XML and HTML parsers
 with an extensible configuration system, build on top of libxml2.
 
 =item Simple now, complex later
@@ -86,7 +86,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy/Indexer.pm
+++ b/lib/Dezi/Lucy/Indexer.pm
@@ -648,7 +648,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy/InvIndex.pm
+++ b/lib/Dezi/Lucy/InvIndex.pm
@@ -39,7 +39,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy/Result.pm
+++ b/lib/Dezi/Lucy/Result.pm
@@ -29,7 +29,7 @@ the L<Dezi::Result> documentation.
 
 =head2 relevant_fields
 
-Returns an ARRAY ref of the field names in the result 
+Returns an ARRAY ref of the field names in the result
 that matched the query. Will only be populated if
 the Results object had find_relevant_fields() set to true.
 
@@ -101,7 +101,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy/Results.pm
+++ b/lib/Dezi/Lucy/Results.pm
@@ -90,7 +90,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -72,7 +72,7 @@ including:
 Only new and overridden methods are documented here. See
 the L<Dezi::Searcher> documentation.
 
-=head2 BUILD 
+=head2 BUILD
 
 Called internally by new(). Additional parameters include:
 
@@ -184,7 +184,7 @@ sub _build_lucy {
     return $self;
 }
 
-=head2 get_propnames 
+=head2 get_propnames
 
 Returns array ref of PropertyNames defined for the invindex.
 The array will not contain any alias names or reserved PropertyNames.
@@ -528,7 +528,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Queue.pm
+++ b/lib/Dezi/Queue.pm
@@ -130,7 +130,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -172,7 +172,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/ReplaceRules.pm
+++ b/lib/Dezi/ReplaceRules.pm
@@ -195,7 +195,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -237,7 +237,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Result.pm
+++ b/lib/Dezi/Result.pm
@@ -149,7 +149,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Results.pm
+++ b/lib/Dezi/Results.pm
@@ -77,7 +77,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Role.pm
+++ b/lib/Dezi/Role.pm
@@ -96,7 +96,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Searcher.pm
+++ b/lib/Dezi/Searcher.pm
@@ -189,7 +189,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Searcher/SearchOpts.pm
+++ b/lib/Dezi/Searcher/SearchOpts.pm
@@ -93,7 +93,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/Doc.pm
+++ b/lib/Dezi/Test/Doc.pm
@@ -59,7 +59,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/Indexer.pm
+++ b/lib/Dezi/Test/Indexer.pm
@@ -88,7 +88,7 @@ Dezi::Test::Indexer - test indexer class
 
 =head1 DESCRIPTION
 
-Dezi::Test::Indexer uses Dezi::Test::InvIndex for 
+Dezi::Test::Indexer uses Dezi::Test::InvIndex for
 running tests on the API, particularly Aggregator classes.
 
 =head1 CONSTANTS
@@ -124,7 +124,7 @@ Peter Karman, E<lt>perl@peknet.comE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-swish-prog at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll
 automatically be notified of progress on your bug as I make changes.
 
@@ -166,7 +166,7 @@ L<http://search.cpan.org/dist/Dezi-App/>
 Copyright 2008-2015 by Peter Karman
 
 This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself. 
+it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 

--- a/lib/Dezi/Test/InvIndex.pm
+++ b/lib/Dezi/Test/InvIndex.pm
@@ -107,7 +107,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/Result.pm
+++ b/lib/Dezi/Test/Result.pm
@@ -23,7 +23,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/Results.pm
+++ b/lib/Dezi/Test/Results.pm
@@ -34,7 +34,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/ResultsPayload.pm
+++ b/lib/Dezi/Test/ResultsPayload.pm
@@ -19,7 +19,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Test/Searcher.pm
+++ b/lib/Dezi/Test/Searcher.pm
@@ -106,7 +106,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Types.pm
+++ b/lib/Dezi/Types.pm
@@ -181,7 +181,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/lib/Dezi/Utils.pm
+++ b/lib/Dezi/Utils.pm
@@ -215,7 +215,7 @@ this method eases the pain.
 I<key> should be a SWISH::3::Config reserved word. Use
 the SWISH::3::Constants for safety.
 
-I<value> is passed through perl_to_xml(). 
+I<value> is passed through perl_to_xml().
 If I<value> is a hashref, it should be a simple key/value set with strings.
 You may use arrayref values, where items in the array are strings.
 
@@ -226,11 +226,11 @@ is missing.
 Example:
 
  use SWISH::3 qw( :constants );
- $utils->merge_swish3_config( 
-     SWISH_PARSERS() => { 
+ $utils->merge_swish3_config(
+     SWISH_PARSERS() => {
          'XML'  => [ 'application/x-bar', 'application/x-foo' ],
-         'HTML' => [ 'application/x-blue', 'application/x-red' ] 
-     } 
+         'HTML' => [ 'application/x-blue', 'application/x-red' ]
+     }
  );
  $utils->merge_swish3_config(
      'foo' => 'bar'
@@ -319,7 +319,7 @@ Peter Karman, E<lt>karpet@dezi.orgE<gt>
 =head1 BUGS
 
 Please report any bugs or feature requests to C<bug-dezi-app at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.  
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Dezi-App>.
 I will be notified, and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT

--- a/t/012-spider-server.t
+++ b/t/012-spider-server.t
@@ -205,21 +205,21 @@ SKIP: {
 	    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 	<url>
-		<loc>$base/hello</loc> 
-		<lastmod>$now+00:00</lastmod> 
-		<changefreq>weekly</changefreq> 
+		<loc>$base/hello</loc>
+		<lastmod>$now+00:00</lastmod>
+		<changefreq>weekly</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
-		<loc>$base/nosuchlink</loc> 
-		<lastmod>$yesterday+00:00</lastmod> 
-		<changefreq>daily</changefreq> 
+		<loc>$base/nosuchlink</loc>
+		<lastmod>$yesterday+00:00</lastmod>
+		<changefreq>daily</changefreq>
 		<priority>0.6</priority>
 	</url>
 	<url>
-		<loc>http://elsewhere.foo/bar</loc> 
-		<lastmod>$yesterday+00:00</lastmod> 
-		<changefreq>hourly</changefreq> 
+		<loc>http://elsewhere.foo/bar</loc>
+		<lastmod>$yesterday+00:00</lastmod>
+		<changefreq>hourly</changefreq>
 		<priority>0.6</priority>
 	</url>
 </urlset>

--- a/t/config2/example3.config
+++ b/t/config2/example3.config
@@ -18,7 +18,7 @@
 # returned when running swish (see the -H switch).
 
 IndexName "Test index"
-IndexDescription "This is an index of our two document directories." 
+IndexDescription "This is an index of our two document directories."
 IndexPointer "http://someplace"
 IndexAdmin "Doc Manager (dmanager@foo.invalid)"
 

--- a/t/config2/example9.config
+++ b/t/config2/example9.config
@@ -46,7 +46,7 @@
 #  Run this example as:
 #
 #     swish-e -S prog -c example9.config
-# 
+#
 #---------------------------------------------------
 
 # Include our site-wide configuration settings:

--- a/t/lucy/fields.conf
+++ b/t/lucy/fields.conf
@@ -1,4 +1,4 @@
 MetaNames foo bing tokenizecasesensitive
 PropertyNames bar
-PropertyNamesIgnoreCase bing storecaseinsensitive 
+PropertyNamesIgnoreCase bing storecaseinsensitive
 PropertyNamesCompareCase tokenizecasesensitive multivaluestore

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,4 +1,4 @@
-#!perl 
+#!perl
 
 use Test::More;
 plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,4 +1,4 @@
-#!perl 
+#!perl
 
 use Test::More;
 plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged. I've split the commits so that you can cherry pick them as required. If you want these changes to be bundled into one commit, just let me know and I'll update the PR and resubmit.