### PR TITLE
Use strict pragma in source files

### DIFF
--- a/lib/Dezi/Types.pm
+++ b/lib/Dezi/Types.pm
@@ -1,4 +1,8 @@
 package Dezi::Types;
+
+use strict;
+use warnings;
+
 use Type::Library -base, -declare => qw(
     DeziFileRules
     DeziIndexerConfig

--- a/t/lucy/000-load.t
+++ b/t/lucy/000-load.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use strict;
+use warnings;
+
 use Test::More tests => 2;
 
 BEGIN {

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,5 +1,8 @@
 #!perl
 
+use strict;
+use warnings;
+
 use Test::More;
 plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};
 sub Pod::Coverage::TRACE_ALL () { 1 }

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,8 @@
 #!perl
 
+use strict;
+use warnings;
+
 use Test::More;
 plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};
 eval "use Test::Pod 1.14";


### PR DESCRIPTION
[CPANTS](https://cpants.cpanauthors.org/dist/Dezi-App) noticed that the `strict` pragma was missing from some files.  Using this pragma is considered to be part of current best practices, hence it is part of the core CPANTS kwalitee measure.  This patch adds the missing `strict` pragmas and resolves the [use_strict](https://cpants.cpanauthors.org/kwalitee/use_strict) issue.