### PR TITLE
Remove dependency on Moo

### DIFF
--- a/t/000-load.t
+++ b/t/000-load.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-use Moo;
+use Moose;
 use Test::More tests => 8;
 
 use_ok('Dezi::App');


### PR DESCRIPTION
The entire distribution uses `Moose`, however one test file was using `Moo`.  It seemed unnecessary to have the extra dependency, hence I propose to remove it here.