### PR TITLE
Fix typos in pod

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -10,7 +10,7 @@
 
 Dezi::App is a Moose port of SWISH::Prog.
 
-Dezi::App drops compatability with Swish-e version 2.x and focuses
+Dezi::App drops compatibility with Swish-e version 2.x and focuses
 on tight integration with SWISH::3 and Apache Lucy.
 
 =head2 INSTALLATION

--- a/lib/Dezi/Aggregator/Spider.pm
+++ b/lib/Dezi/Aggregator/Spider.pm
@@ -153,7 +153,7 @@ need to be fetched.
 
 =item ua I<lwp_useragent>
 
-Get/set the Dezi::Aggregagor::Spider::UA object.
+Get/set the Dezi::Aggregator::Spider::UA object.
 
 =item max_depth I<n>
 
@@ -173,7 +173,7 @@ next server, if any.  The default is to not limit by time.
 This optional key sets the max number of files to spider before aborting.
 The default is to not limit by number of files.  This is the number of requests
 made to the remote server, not the total number of files to index (see C<max_indexed>).
-This count is displayted at the end of indexing as C<Unique URLs>.
+This count is displayed at the end of indexing as C<Unique URLs>.
 
 This feature can (and perhaps should) be use when spidering a web site where dynamic
 content may generate unique URLs to prevent run-away spidering.

--- a/lib/Dezi/Aggregator/Spider/Response.pm
+++ b/lib/Dezi/Aggregator/Spider/Response.pm
@@ -233,7 +233,7 @@ sub title {
     return $p->header('Title');
 }
 
-# delegate all other method calls the the http_response object.
+# delegate all other method calls to the http_response object.
 # cribbed from HTTP::Message
 our $AUTOLOAD;
 

--- a/lib/Dezi/InvIndex.pm
+++ b/lib/Dezi/InvIndex.pm
@@ -179,7 +179,7 @@ their IR library specifics.
 
 =head2 clobber
 
-Get/set the boolean indicating whether the index should overwrite
+Get/set the Boolean indicating whether the index should overwrite
 any existing index with the same name. The default is true.
 
 =head2 new_from_meta

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -167,7 +167,7 @@ Default is C<swish.xml>.
 
 =head2 swish_header_file
 
-Alias for header_file(). For backwards compatability with SWISH::Prog.
+Alias for header_file(). For backwards compatibility with SWISH::Prog.
 
 =head2 BUILD
 

--- a/lib/Dezi/Lucy/Indexer.pm
+++ b/lib/Dezi/Lucy/Indexer.pm
@@ -637,7 +637,7 @@ The libswish3 XML and HTML parsers will automatically treat a <title> tag as swi
 
 =item
 
-Things get complicated quickly when defining fields. Experiment with small test cases to arrive a the configuration that works best with your application.
+Things get complicated quickly when defining fields. Experiment with small test cases to arrive at the configuration that works best with your application.
 
 =back
 

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -225,7 +225,7 @@ The B<order> param in I<opts> may be a Lucy::Search::SortSpec object.
 
 =item default_boolop
 
-The default boolean connector for parsing I<query>. Valid values
+The default Boolean connector for parsing I<query>. Valid values
 are B<AND> and B<OR>. The default is
 B<AND> (which is different than Lucy::QueryParser, but the
 same as Swish-e).

--- a/lib/Dezi/Searcher/SearchOpts.pm
+++ b/lib/Dezi/Searcher/SearchOpts.pm
@@ -79,7 +79,7 @@ and an upper limit.
 
 =item default_boolop
 
-The default boolean connector for parsing I<query>. Valid values
+The default Boolean connector for parsing I<query>. Valid values
 are B<AND> and B<OR>. The default is
 B<AND> (which is different than Lucy::QueryParser, but the
 same as Swish-e).


### PR DESCRIPTION
I happened to come across some typos in the docs, which I've fixed here.  I've split one change out into a separate commit so that you can cherry pick it if you need to.