### PR TITLE
Fix POD warnings

### DIFF
--- a/lib/Dezi/CLI.pm
+++ b/lib/Dezi/CLI.pm
@@ -174,12 +174,6 @@ has 'warnings' => (
     default     => sub {2},
 );
 
-=head2 run
-
-Main method. Calls commands passed via @ARGV.
-
-=cut
-
 sub _getopt_full_usage {
     my ( $self, $usage ) = @_;
     $usage->die( { post_text => $self->_commands } );
@@ -587,6 +581,10 @@ The Dezi::CLI class is a port of the B<swish3> tool to a proper class,
 using L<MooseX::Getopt>.
 
 =head1 METHODS
+
+=head2 run
+
+Main method. Calls commands passed via @ARGV.
 
 =head2 index
 

--- a/lib/Dezi/InvIndex/Header.pm
+++ b/lib/Dezi/InvIndex/Header.pm
@@ -156,7 +156,11 @@ at this time.
 All the L<SWISH::3> constants are imported into this namespace,
 including:
 
-=head2 SWISH_DOC_PROP_MAP
+=over 4
+
+=item * SWISH_DOC_PROP_MAP
+
+=back
 
 =head1 METHODS
 

--- a/lib/Dezi/Lucy/Searcher.pm
+++ b/lib/Dezi/Lucy/Searcher.pm
@@ -65,7 +65,11 @@ recommends the switch to using Lucy::Search::Searcher directly.
 All the L<SWISH::3> constants are imported into this namespace,
 including:
 
-=head2 SWISH_DOC_PROP_MAP
+=over 4
+
+=item * SWISH_DOC_PROP_MAP
+
+=back
 
 =head1 METHODS
 

--- a/lib/Dezi/Result.pm
+++ b/lib/Dezi/Result.pm
@@ -42,11 +42,19 @@ Returns the ranking score for the Result.
 
 =head2 uri
 
+URL or filepath to document.
+
 =head2 mtime
+
+Last modified date of document.
 
 =head2 title
 
+Document title.
+
 =head2 summary
+
+Description of document.
 
 =head2 swishdocpath
 

--- a/lib/Dezi/Test/Doc.pm
+++ b/lib/Dezi/Test/Doc.pm
@@ -32,6 +32,15 @@ Dezi::Test::Doc - test Document class for Dezi::Test::Result
 
 =head1 SYNOPSIS
 
+    use Dezi::Test::Doc;
+
+    my %doc;  # holds all the parsed text, keyed by field name
+    ... construct %doc hash ...
+    my $test_doc = Dezi::Test::Doc->new( %doc );
+
+    print $test_doc->swishtitle, "\n";
+    print $test_doc->swishdescription, "\n";
+
 =head1 METHODS
 
 =head2 SWISH_DOC_PROP_MAP

--- a/lib/Dezi/Test/Doc.pm
+++ b/lib/Dezi/Test/Doc.pm
@@ -40,9 +40,15 @@ All attributes defined in L<SWISH::3> SWISH_DOC_PROP_MAP hash.
 
 =head2 swishdefault
 
+A Metaname that is used by Swish-e if no other name is specified.
+
 =head2 swishtitle
 
+Document title.
+
 =head2 swishdescription
+
+Description of document.
 
 =head2 uri
 

--- a/lib/Dezi/Test/Indexer.pm
+++ b/lib/Dezi/Test/Indexer.pm
@@ -96,7 +96,11 @@ running tests on the API, particularly Aggregator classes.
 All the L<SWISH::3> constants are imported into this namespace,
 including:
 
-=head2 SWISH_DOC_PROP_MAP
+=over 4
+
+=item * SWISH_DOC_PROP_MAP
+
+=back
 
 =head1 METHODS
 

--- a/lib/Dezi/Test/InvIndex.pm
+++ b/lib/Dezi/Test/InvIndex.pm
@@ -6,26 +6,6 @@ use Carp;
 use Dezi::Cache;
 use Data::Dump qw( dump );
 
-=head1 NAME
-
-Dezi::Test::InvIndex - test in-memory invindex
-
-=head1 METHODS
-
-=head2 term_cache
-
-=head2 doc_cache
-
-=head2 open
-
-=head2 search
-
-=head2 put_doc
-
-=head2 get_doc
-
-=cut
-
 # in memory invindex
 has 'term_cache' => (
     is      => 'rw',
@@ -99,6 +79,36 @@ sub get_doc {
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+=head1 NAME
+
+Dezi::Test::InvIndex - test in-memory invindex
+
+=head1 METHODS
+
+=head2 term_cache
+
+Accessor for the term cache.
+
+=head2 doc_cache
+
+Accessor for the document cache.
+
+=head2 open
+
+Currently a no-op.
+
+=head2 search($query)
+
+Search the document cache with the given query and return a hash of the hits found.
+
+=head2 put_doc($doc)
+
+Add the given document to the document cache.
+
+=head2 get_doc($uri)
+
+Return the document from the given URI.
 
 =head1 AUTHOR
 

--- a/lib/Dezi/Test/Results.pm
+++ b/lib/Dezi/Test/Results.pm
@@ -27,6 +27,8 @@ Dezi::Test::Results - test results class
 
 =head2 next
 
+Return the next test Result.
+
 =head1 AUTHOR
 
 Peter Karman, E<lt>karpet@dezi.orgE<gt>


### PR DESCRIPTION
`podchecker` produced several warnings; most were (effectively) due to missing method documentation.  The commits in this PR adapt the POD to conform to the relevant standards and adds missing docs where possible.  It's probably a good idea to check that I've definitely understood what the code does, so that the docs match the code properly!