### PR TITLE
Use stricter UTF8 validation

### DIFF
--- a/bin/lucyx-dump-terms
+++ b/bin/lucyx-dump-terms
@@ -7,7 +7,7 @@ my $usage = "$0 path/to/index\n";
 
 die $usage unless @ARGV;
 
-binmode STDOUT, ":utf8";
+binmode STDOUT, ":encoding(UTF-8)";
 
 for my $invindex (@ARGV) {
     my $reader      = Lucy::Index::IndexReader->open( index => $invindex );

--- a/lib/Dezi/Indexer/Config.pm
+++ b/lib/Dezi/Indexer/Config.pm
@@ -572,7 +572,7 @@ sub stringify {
 
 sub _write_utf8 {
     my ( $self, $file, $buf ) = @_;
-    binmode $file, ':utf8';
+    binmode $file, ':encoding(UTF-8)';
     print {$file} $buf;
 }
 


### PR DESCRIPTION
It's currently considered best practice to use 'encoding(UTF-8)' instead
of 'utf8' when reading and writing files, hence this change.