### PR TITLE
Test spider functionality on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ perl:
     - "5.12"
     - "5.10"
 
+env:
+    - TEST_SPIDER=1
+
 install:
     - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
     - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }


### PR DESCRIPTION
This patch extends how much is tested on Travis, so that any problems are caught earlier.