### PR TITLE
Avoid stringy eval

### DIFF
--- a/lib/Dezi/ReplaceRules.pm
+++ b/lib/Dezi/ReplaceRules.pm
@@ -170,6 +170,7 @@ sub apply {
 
             #warn "code='$code'\n";
             try {
+                ## no critic (ProhibitStringyEval)
                 eval "$code";
             }
             catch {

--- a/t/003-spider.t
+++ b/t/003-spider.t
@@ -1,7 +1,9 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+
 use Test::More tests => 2;
+use Class::Load qw(try_load_class);
 
 SKIP: {
 
@@ -12,10 +14,8 @@ SKIP: {
         skip "set TEST_SPIDER env var to test the spider", 2;
     }
 
-    eval "use Dezi::Aggregator::Spider";
-    if ( $@ && $@ =~ m/([\w:]+)/ ) {
-        skip "$1 required for spider test: $@", 3;
-    }
+    try_load_class("Dezi::Aggregator::Spider")
+        or skip "Dezi::Aggregator::Spider required for spider test: $@", 3;
 
     ok( my $spider = Dezi::Aggregator::Spider->new(
             verbose   => $ENV{DEZI_DEBUG},

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -4,11 +4,15 @@ use strict;
 use warnings;
 
 use Test::More;
+use Class::Load qw(try_load_class);
+
 plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};
+
 sub Pod::Coverage::TRACE_ALL () { 1 }
-eval "use Test::Pod::Coverage 1.04";
-plan skip_all => "Test::Pod::Coverage 1.04 required for testing POD coverage"
-  if $@;
 
-all_pod_coverage_ok();
+my $min_tpc_version = 1.04;
+try_load_class( "Test::Pod::Coverage", { -version => $min_tpc_version } )
+  or plan skip_all =>
+  "Test::Pod::Coverage $min_tpc_version required for testing POD coverage";
 
+Test::Pod::Coverage::all_pod_coverage_ok();

--- a/t/pod.t
+++ b/t/pod.t
@@ -4,8 +4,12 @@ use strict;
 use warnings;
 
 use Test::More;
-plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};
-eval "use Test::Pod 1.14";
-plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
-all_pod_files_ok();
+use Class::Load qw(try_load_class);
 
+plan skip_all => "set RELEASE_TESTING to test POD" unless $ENV{RELEASE_TESTING};
+
+my $min_tp_version = 1.14;
+try_load_class( 'Test::Pod', { -version => $min_tp_version } )
+  or plan skip_all => "Test::Pod $min_tp_version required for testing POD";
+
+Test::Pod::all_pod_files_ok();


### PR DESCRIPTION
Usually, when one wants to check for availability of a given module, it is better to use `Class::Load` than to call `use` within a string evaluation.  Hence the motivation for this pull request.  The main thing that I think you should check is the commit I made to replace stringy eval in the spider tests: I altered the existing behaviour slightly in that, if `Dezi::Aggregator::Spider` is not present, then the tests are skipped.  The match for the error message has been left out in the new version of the code.  I *think* this is ok (it wasn't 100% clear to me what the extra match was achieving, other than providing information about which module was required for the spider tests); if this change isn't ok, then I don't have any problems with leaving it out.  Alternatively, if you'd like some particular kind of extra functionality here, just let me know and I can update the PR as necessary.